### PR TITLE
Fix: Adjust CPU allocation for codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
   "runArgs": [
     "--memory=6g",
     "--memory-swap=8g",
-    "--cpus=3.5",
+    "--cpus=2",
     "--oom-kill-disable",
     "--security-opt=no-new-privileges:true"
   ],


### PR DESCRIPTION
Changed the --cpus value in runArgs from 3.5 to 2 in .devcontainer/devcontainer.json to match available resources and prevent container creation failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the CPU allocation for the development container environment to 2 CPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->