### PR TITLE
Fix: Exclude server tests from type-aware linting

### DIFF
--- a/config/eslint/eslint.config.js
+++ b/config/eslint/eslint.config.js
@@ -110,7 +110,7 @@ export default tseslint.config(
       languageOptions: {
       globals: globals.node,
         parserOptions: {
-          project: "./server/tsconfig.json",
+          project: "./server/tsconfig.eslint.json",
           tsconfigRootDir: process.cwd(),
         },
       },

--- a/server/tsconfig.eslint.json
+++ b/server/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}


### PR DESCRIPTION
I created a tsconfig.eslint.json for the server directory to exclude test files (**.test.ts, **.spec.ts) from type-aware linting. I updated the ESLint configuration (config/eslint/eslint.config.js) to use this new tsconfig for the server code, preventing type errors related to test-specific code patterns.